### PR TITLE
fix: compiling errors from footprint_extruder.cpp

### DIFF
--- a/extensions/footprint_extruder/footprint_extruder.cpp
+++ b/extensions/footprint_extruder/footprint_extruder.cpp
@@ -13,8 +13,10 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #define N_DIM 5
 
+#include <array>
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>

--- a/extensions/grid_encoder/bindings.cpp
+++ b/extensions/grid_encoder/bindings.cpp
@@ -8,7 +8,7 @@
  * @Ref: https://github.com/ashawkey/torch-ngp
  */
 
-#include <stdint.h>
+#include <cstdint>
 #include <torch/extension.h>
 #include <torch/torch.h>
 

--- a/extensions/grid_encoder/grid_encoder_ext.cu
+++ b/extensions/grid_encoder/grid_encoder_ext.cu
@@ -17,9 +17,10 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <type_traits>
 
 #include <cstdio>
-#include <stdint.h>
+#include <cstdint>
 
 #define CHECK_CUDA(x)                                                          \
   TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")


### PR DESCRIPTION
Fixes #7

`extensions/footprint_extruder/footprint_extruder.cpp`, `std::array` is used without including `<array>`, which may cause compiling errors in certain environments. To fix this error and prevent future errors we:

- added `#include <array>` and `#include <limits>` to `extensions/footprint_extruder/footprint_extruder.cpp`,
- added `#include <type_traits>` to `extensions/grid_encoder/grid_encoder_ext.cu`, and
- changed `#include <stdint.h>` to `#include <cstdint>` in `extensions/grid_encoder/{bindings.cpp,grid_encoder_ext.cu}`.